### PR TITLE
Use explicit version numbers for workspace crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "dabl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "generate-dbus-resolve1"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dbus",
  "dbus-codegen",
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "libdnscheck"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dbus",
  "dbus-tree",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "rblcheck"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/dabl/Cargo.toml
+++ b/dabl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dabl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 edition = "2018"
 default-run = "dabl"
@@ -11,4 +11,4 @@ default-run = "dabl"
 anyhow = "~1.0"
 clap = "~2.33"
 
-libdnscheck = { path = "../libdnscheck", version = "0.1.0" }
+libdnscheck = { path = "../libdnscheck", version = "0.2.0" }

--- a/dabl/Cargo.toml
+++ b/dabl/Cargo.toml
@@ -1,5 +1,12 @@
 [package]
 name = "dabl"
+description = "Checks DNS allow- and deny-lists"
+homepage = "https://github.com/andrewaylett/dabl"
+readme = "README.md"
+
+repository = "https://github.com/andrewaylett/dabl"
+license = "Apache-2.0"
+
 version = "0.2.0"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 edition = "2018"

--- a/dabl/Cargo.toml
+++ b/dabl/Cargo.toml
@@ -11,4 +11,4 @@ default-run = "dabl"
 anyhow = "~1.0"
 clap = "~2.33"
 
-libdnscheck = { path = "../libdnscheck" }
+libdnscheck = { path = "../libdnscheck", version = "0.1.0" }

--- a/generate-dbus-resolve1/Cargo.toml
+++ b/generate-dbus-resolve1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generate-dbus-resolve1"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 edition = "2018"
 

--- a/generate-dbus-resolve1/Cargo.toml
+++ b/generate-dbus-resolve1/Cargo.toml
@@ -1,5 +1,12 @@
 [package]
 name = "generate-dbus-resolve1"
+description = "Resolves DNS using DBus"
+homepage = "https://github.com/andrewaylett/dabl"
+readme = "README.md"
+
+repository = "https://github.com/andrewaylett/dabl"
+license = "Apache-2.0"
+
 version = "0.2.0"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 edition = "2018"

--- a/libdnscheck/Cargo.toml
+++ b/libdnscheck/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdnscheck"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 edition = "2018"
 
@@ -12,4 +12,4 @@ dbus = "0.9.1"
 dbus-tree = "0.9.0"
 libc = "0.2.86"
 
-generate-dbus-resolve1 = { path = "../generate-dbus-resolve1", version = "0.1.0" }
+generate-dbus-resolve1 = { path = "../generate-dbus-resolve1", version = "0.2.0" }

--- a/libdnscheck/Cargo.toml
+++ b/libdnscheck/Cargo.toml
@@ -1,5 +1,12 @@
 [package]
 name = "libdnscheck"
+description = "Checks DNS allow- and deny-lists"
+homepage = "https://github.com/andrewaylett/dabl"
+readme = "README.md"
+
+repository = "https://github.com/andrewaylett/dabl"
+license = "Apache-2.0"
+
 version = "0.2.0"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 edition = "2018"

--- a/libdnscheck/Cargo.toml
+++ b/libdnscheck/Cargo.toml
@@ -12,4 +12,4 @@ dbus = "0.9.1"
 dbus-tree = "0.9.0"
 libc = "0.2.86"
 
-generate-dbus-resolve1 = { path = "../generate-dbus-resolve1" }
+generate-dbus-resolve1 = { path = "../generate-dbus-resolve1", version = "0.1.0" }

--- a/rblcheck/Cargo.toml
+++ b/rblcheck/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
 homepage = "https://github.com/andrewaylett/rblcheck"
 readme = "README.md"
 
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/andrewaylett/rblcheck"
 license = "Apache-2.0"
 
@@ -17,4 +17,4 @@ edition = "2018"
 anyhow = "~1.0"
 clap = "~2.33"
 
-libdnscheck = { path = "../libdnscheck", version = "0.1.0" }
+libdnscheck = { path = "../libdnscheck", version = "0.2.0" }

--- a/rblcheck/Cargo.toml
+++ b/rblcheck/Cargo.toml
@@ -17,4 +17,4 @@ edition = "2018"
 anyhow = "~1.0"
 clap = "~2.33"
 
-libdnscheck = { path = "../libdnscheck" }
+libdnscheck = { path = "../libdnscheck", version = "0.1.0" }

--- a/rblcheck/Cargo.toml
+++ b/rblcheck/Cargo.toml
@@ -2,11 +2,11 @@
 name = "rblcheck"
 description = "Checks DNS RBLs"
 authors = ["Andrew Aylett <andrew@aylett.co.uk>"]
-homepage = "https://github.com/andrewaylett/rblcheck"
+homepage = "https://github.com/andrewaylett/dabl"
 readme = "README.md"
 
 version = "0.2.0"
-repository = "https://github.com/andrewaylett/rblcheck"
+repository = "https://github.com/andrewaylett/dabl"
 license = "Apache-2.0"
 
 edition = "2018"


### PR DESCRIPTION
This seems to be the way.  We'll see how `cargo ws` does at publishing
it.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>