### PR TITLE
Teach dabl about "quiet" and "verbose"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: '2.3.5'
     hooks:
       - id: editorconfig-checker
-        types:
+        types_or:
           - rust
           - toml
           - yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +166,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "lazy_static",
  "libdnscheck",
 ]
 

--- a/dabl/README.md
+++ b/dabl/README.md
@@ -40,3 +40,21 @@ OPTIONS:
 ARGS:
     <query>...
 ```
+
+TCP Wrappers
+------------
+
+The Author uses `dabl` to restrict access to his IMAP service using TCP Wrappers.
+Regular DNSBLs aren't intended to restrict access to consumer-facing services; you probably don't want to block the "Dial-Up Address List", for example.
+Spamhaus has a subscription list called "AuthBL" which contains IPs observed attempting credential stuffing.
+I have no interest apart from being a very happy user of their free subscription.
+
+Adding this line to `/etc/hosts.allow` and enabling the relevant configuration in your service will let you query the lists of your choice.
+
+```
+imap, imaps: ALL: aclexec /usr/local/bin/dabl -a al.aylett.co.uk -b bl.aylett.co.uk -b YOUR_KEY_HERE.authbl.dq.spamhaus.net %a
+```
+
+Note that the Author's allow and block lists are not general-purpose, and you'll need a key for SpamHaus.
+Copy and paste at your own risk!
+If you want to run your own DNS allow- and block-lists, you may find [rbldnsd](https://rbldnsd.io/) to be useful.

--- a/rblcheck/Cargo.toml
+++ b/rblcheck/Cargo.toml
@@ -16,5 +16,6 @@ edition = "2018"
 [dependencies]
 anyhow = "~1.0"
 clap = "~2.33"
+lazy_static = "1.4.0"
 
 libdnscheck = { path = "../libdnscheck", version = "0.2.0" }


### PR DESCRIPTION
This adds the command line options -q and -v, respectively.

Plus extra bonus pre-commit fixes and a block in the readme about how
and why I use the tool.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>