### PR TITLE
Revert a no-op edit to build.rs

### DIFF
--- a/generate-dbus-resolve1/build.rs
+++ b/generate-dbus-resolve1/build.rs
@@ -1,8 +1,7 @@
+use dbus_codegen::GenOpts;
 use std::env;
 use std::fs;
 use std::path::Path;
-
-use dbus_codegen::GenOpts;
 
 const PREFIX: &str = "OrgFreedesktop";
 const COMMAND_LINE: &str = "gdbus introspect --system --dest org.freedesktop.resolve1 --object-path /org/freedesktop/resolve1 --xml";


### PR DESCRIPTION
This is because the crate hasn't _really_ changed but some tooling
thinks it might have done.

Signed-off-by: Andrew Aylett <andrew@aylett.co.uk>